### PR TITLE
Add search and HTML export to news app

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ News API. In addition to browsing predefined categories, it now supports
 real‑time search across multiple sources and languages. Run the application with:
 
 ```bash
+export NEWSAPI_KEY="your_api_key"
 python news_app.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,3 +101,17 @@ Another option is hardcoding your console to only print in utf-8. This is a bad 
 
 Feel free to make suggestions or provide feedback regarding the library. Thanks.
 Reach out at [lisivickmatt@gmail.com]('mailto:lisivickmatt@gmail.com')
+
+## Example Application
+
+The repository includes `news_app.py`, a simple Tkinter-based reader for the
+News API. In addition to browsing predefined categories, it now supports
+real‑time search across multiple sources and languages. Run the application with:
+
+```bash
+python news_app.py
+```
+
+Enter a keyword, optional source, and date in the search panel and choose
+English or Arabic. Results are shown in the interface and saved to
+`search_results.html` for convenient viewing in a browser.

--- a/news_app.py
+++ b/news_app.py
@@ -1,10 +1,15 @@
 from tkinter import *
 from tkinter import messagebox
+from urllib.parse import urlencode
+import os
 import requests
 
 # Constants
-API_KEY = '24998c027203417cb77e2d0609741910'
-BASE_URL = 'http://newsapi.org/v2/top-headlines?country=in&category={}&apiKey=' + API_KEY
+API_KEY = os.getenv("NEWSAPI_KEY", "24998c027203417cb77e2d0609741910")
+BASE_URL = (
+    'http://newsapi.org/v2/top-headlines?country=in&category={}&apiKey=' + API_KEY
+)
+EVERYTHING_URL = 'https://newsapi.org/v2/everything?'
 
 class NewsApp:
     def __init__(self, root):
@@ -25,14 +30,94 @@ class NewsApp:
                       pady=2, bd=12, relief=GROOVE, bg=bg_color, fg=basic_font_color)
         title.pack(fill=X)
 
+        # ==== Search Frame ==== #
+        search_frame = LabelFrame(
+            self.root,
+            text="Search",
+            font=("times new roman", 20, "bold"),
+            bg=bg_color,
+            fg=basic_font_color,
+            bd=10,
+            relief=GROOVE,
+        )
+        search_frame.place(x=0, y=80, width=300, height=260)
+
+        # Keyword
+        Label(
+            search_frame,
+            text="Keyword",
+            font=("arial", 12, "bold"),
+            bg=bg_color,
+            fg=basic_font_color,
+        ).grid(row=0, column=0, padx=5, pady=5, sticky="w")
+        self.query_entry = Entry(search_frame, font=("arial", 12))
+        self.query_entry.grid(row=0, column=1, padx=5, pady=5)
+
+        # Source filter
+        Label(
+            search_frame,
+            text="Source",
+            font=("arial", 12, "bold"),
+            bg=bg_color,
+            fg=basic_font_color,
+        ).grid(row=1, column=0, padx=5, pady=5, sticky="w")
+        self.source_entry = Entry(search_frame, font=("arial", 12))
+        self.source_entry.grid(row=1, column=1, padx=5, pady=5)
+
+        # Date filter
+        Label(
+            search_frame,
+            text="From (YYYY-MM-DD)",
+            font=("arial", 12, "bold"),
+            bg=bg_color,
+            fg=basic_font_color,
+        ).grid(row=2, column=0, padx=5, pady=5, sticky="w")
+        self.from_entry = Entry(search_frame, font=("arial", 12))
+        self.from_entry.grid(row=2, column=1, padx=5, pady=5)
+
+        # Language option
+        Label(
+            search_frame,
+            text="Language",
+            font=("arial", 12, "bold"),
+            bg=bg_color,
+            fg=basic_font_color,
+        ).grid(row=3, column=0, padx=5, pady=5, sticky="w")
+        self.lang_var = StringVar(value="en")
+        OptionMenu(search_frame, self.lang_var, "en", "ar").grid(
+            row=3, column=1, padx=5, pady=5
+        )
+
+        Button(
+            search_frame,
+            text="SEARCH",
+            width=20,
+            bd=7,
+            font="arial 12 bold",
+            command=self.search_news,
+        ).grid(row=4, column=0, columnspan=2, padx=10, pady=5)
+
         # ==== Category Frame ==== #
-        category_frame = LabelFrame(self.root, text="Category", font=("times new roman", 20, "bold"),
-                                    bg=bg_color, fg=basic_font_color, bd=10, relief=GROOVE)
-        category_frame.place(x=0, y=80, width=300, relheight=0.88)
+        category_frame = LabelFrame(
+            self.root,
+            text="Category",
+            font=("times new roman", 20, "bold"),
+            bg=bg_color,
+            fg=basic_font_color,
+            bd=10,
+            relief=GROOVE,
+        )
+        category_frame.place(x=0, y=350, width=300, relheight=0.6)
 
         for idx, category in enumerate(self.news_categories):
-            button = Button(category_frame, text=category.upper(), width=20, bd=7, font="arial 15 bold",
-                            command=lambda c=category: self.display_news(c))
+            button = Button(
+                category_frame,
+                text=category.upper(),
+                width=20,
+                bd=7,
+                font="arial 15 bold",
+                command=lambda c=category: self.display_news(c),
+            )
             button.grid(row=idx, column=0, padx=10, pady=5)
 
         # ==== News Frame ==== #
@@ -77,6 +162,63 @@ class NewsApp:
                 messagebox.showerror("Error", f"HTTP Error: {e}")
         except Exception as e:
             messagebox.showerror("Error", f"An error occurred: {e}")
+
+    def search_news(self):
+        query = self.query_entry.get()
+        source = self.source_entry.get()
+        from_date = self.from_entry.get()
+        language = self.lang_var.get()
+
+        if not query:
+            messagebox.showerror("Error", "Please enter a keyword to search.")
+            return
+
+        params = {"q": query, "apiKey": API_KEY, "language": language}
+        if source:
+            params["sources"] = source
+        if from_date:
+            params["from"] = from_date
+        url = EVERYTHING_URL + urlencode(params)
+
+        self.news_text_area.delete("1.0", END)
+        self.news_text_area.insert(END, f"Searching for: {query}\n\n")
+
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+            articles = response.json().get("articles", [])
+
+            if articles:
+                for article in articles:
+                    self.news_text_area.insert(END, f"Title: {article['title']}\n")
+                    self.news_text_area.insert(
+                        END, f"Description: {article.get('description', 'No description')}\n"
+                    )
+                    self.news_text_area.insert(END, f"Read more: {article['url']}\n")
+                    self.news_text_area.insert(END, "-" * 80 + "\n")
+
+                self.generate_html(articles)
+            else:
+                self.news_text_area.insert(END, "No news articles found.\n")
+        except Exception as e:
+            messagebox.showerror("Error", f"An error occurred: {e}")
+
+    def generate_html(self, articles, filename="search_results.html"):
+        try:
+            with open(filename, "w", encoding="utf-8") as html_file:
+                html_file.write(
+                    "<html><head><meta charset='utf-8'><title>Search Results" "</title></head><body>"
+                )
+                for article in articles:
+                    html_file.write(
+                        f"<h2><a href='{article['url']}'>{article['title']}</a></h2>"
+                    )
+                    html_file.write(
+                        f"<p>{article.get('description', 'No description')}</p><hr>"
+                    )
+                html_file.write("</body></html>")
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to write HTML: {e}")
 
 # Run the application
 if __name__ == "__main__":

--- a/news_app.py
+++ b/news_app.py
@@ -1,15 +1,12 @@
 from tkinter import *
 from tkinter import messagebox
-from urllib.parse import urlencode
 import os
 import requests
 
 # Constants
-API_KEY = os.getenv("NEWSAPI_KEY", "24998c027203417cb77e2d0609741910")
-BASE_URL = (
-    'http://newsapi.org/v2/top-headlines?country=in&category={}&apiKey=' + API_KEY
-)
-EVERYTHING_URL = 'https://newsapi.org/v2/everything?'
+API_KEY = os.getenv("NEWSAPI_KEY")
+BASE_URL = "https://newsapi.org/v2/top-headlines?country=in&category={}&apiKey={}"
+EVERYTHING_URL = "https://newsapi.org/v2/everything"
 
 class NewsApp:
     def __init__(self, root):
@@ -138,7 +135,10 @@ class NewsApp:
         self.news_text_area.pack(fill=BOTH, expand=1)
 
     def display_news(self, category):
-        url = BASE_URL.format(category)
+        if not API_KEY:
+            messagebox.showerror("Error", "NEWSAPI_KEY environment variable not set")
+            return
+        url = BASE_URL.format(category, API_KEY)
         self.news_text_area.delete("1.0", END)
         self.news_text_area.insert(END, f"Fetching news for category: {category.upper()}...\n\n")
 
@@ -173,18 +173,20 @@ class NewsApp:
             messagebox.showerror("Error", "Please enter a keyword to search.")
             return
 
+        if not API_KEY:
+            messagebox.showerror("Error", "NEWSAPI_KEY environment variable not set")
+            return
         params = {"q": query, "apiKey": API_KEY, "language": language}
         if source:
             params["sources"] = source
         if from_date:
             params["from"] = from_date
-        url = EVERYTHING_URL + urlencode(params)
 
         self.news_text_area.delete("1.0", END)
         self.news_text_area.insert(END, f"Searching for: {query}\n\n")
 
         try:
-            response = requests.get(url)
+            response = requests.get(EVERYTHING_URL, params=params, timeout=10)
             response.raise_for_status()
             articles = response.json().get("articles", [])
 
@@ -206,9 +208,11 @@ class NewsApp:
     def generate_html(self, articles, filename="search_results.html"):
         try:
             with open(filename, "w", encoding="utf-8") as html_file:
-                html_file.write(
-                    "<html><head><meta charset='utf-8'><title>Search Results" "</title></head><body>"
-                )
+                html_file.write("""
+<html>
+  <head><meta charset='utf-8'><title>Search Results</title></head>
+  <body>
+""")
                 for article in articles:
                     html_file.write(
                         f"<h2><a href='{article['url']}'>{article['title']}</a></h2>"


### PR DESCRIPTION
## Summary
- add search panel for keyword, source, date and language filters
- fetch matching articles via News API and export results to `search_results.html`
- document example usage in README

## Testing
- `python -m py_compile news_app.py`
- `pip install -r requirements-dev.txt` (fails: Could not find a version that satisfies the requirement flake8)

------
https://chatgpt.com/codex/tasks/task_e_689148c293608331ad366a4e18e1d49a